### PR TITLE
feat(admin): add menu item creation with gallery image picker

### DIFF
--- a/lib/services/image_storage_service.dart
+++ b/lib/services/image_storage_service.dart
@@ -1,0 +1,16 @@
+import 'package:image_picker/image_picker.dart';
+
+import 'image_storage_service_impl.dart'
+    if (dart.library.io) 'image_storage_service_io.dart'
+    if (dart.library.html) 'image_storage_service_web.dart';
+
+abstract class ImageStorageService {
+  /// Returns a value that can be persisted in `MenuItem.imageUrl`.
+  ///
+  /// - On mobile/desktop (io): copies the file into the app documents directory
+  ///   and returns the local file path.
+  /// - On web: returns a `data:image/...;base64,...` URL.
+  static Future<String> persistPickedImage(XFile pickedFile) {
+    return ImageStorageServiceImpl.persistPickedImage(pickedFile);
+  }
+}

--- a/lib/services/image_storage_service_impl.dart
+++ b/lib/services/image_storage_service_impl.dart
@@ -1,0 +1,9 @@
+import 'package:image_picker/image_picker.dart';
+
+/// Fallback implementation (should be overridden by platform implementations).
+class ImageStorageServiceImpl {
+  static Future<String> persistPickedImage(XFile pickedFile) async {
+    // In the worst case, persist the path (may not be stable on all platforms).
+    return pickedFile.path;
+  }
+}

--- a/lib/services/image_storage_service_io.dart
+++ b/lib/services/image_storage_service_io.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+
+class ImageStorageServiceImpl {
+  static Future<String> persistPickedImage(XFile pickedFile) async {
+    final docsDir = await getApplicationDocumentsDirectory();
+    final menuImagesDir = Directory('${docsDir.path}/menu_images');
+    if (!await menuImagesDir.exists()) {
+      await menuImagesDir.create(recursive: true);
+    }
+
+    final source = File(pickedFile.path);
+    final fileName =
+        'menu_${DateTime.now().microsecondsSinceEpoch}_${pickedFile.name}';
+    final target = File('${menuImagesDir.path}/$fileName');
+
+    await source.copy(target.path);
+    return target.path;
+  }
+}

--- a/lib/services/image_storage_service_web.dart
+++ b/lib/services/image_storage_service_web.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+import 'package:image_picker/image_picker.dart';
+
+class ImageStorageServiceImpl {
+  static Future<String> persistPickedImage(XFile pickedFile) async {
+    final bytes = await pickedFile.readAsBytes();
+
+    // Best-effort mime detection based on extension.
+    final nameLower = pickedFile.name.toLowerCase();
+    final mime = nameLower.endsWith('.png')
+        ? 'image/png'
+        : nameLower.endsWith('.gif')
+        ? 'image/gif'
+        : 'image/jpeg';
+
+    final b64 = base64Encode(bytes);
+    return 'data:$mime;base64,$b64';
+  }
+}

--- a/lib/widgets/menu_item_card.dart
+++ b/lib/widgets/menu_item_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import '../models/menu_item.dart';
 import '../utils/constants.dart';
+import 'menu_item_image.dart';
 
 class MenuItemCard extends StatelessWidget {
   final MenuItem item;
@@ -46,16 +46,16 @@ class MenuItemCard extends StatelessWidget {
                   borderRadius: const BorderRadius.vertical(
                     top: Radius.circular(16),
                   ),
-                  child: CachedNetworkImage(
+                  child: MenuItemImage(
                     imageUrl: item.imageUrl,
                     height: 110,
                     width: double.infinity,
                     fit: BoxFit.cover,
-                    placeholder: (context, url) => Container(
+                    placeholder: Container(
                       color: AppColors.background,
                       child: const Center(child: CircularProgressIndicator()),
                     ),
-                    errorWidget: (context, url, error) => Container(
+                    errorWidget: Container(
                       color: AppColors.background,
                       child: const Icon(
                         Icons.restaurant,

--- a/lib/widgets/menu_item_image.dart
+++ b/lib/widgets/menu_item_image.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/widgets.dart';
+
+import 'menu_item_image_impl.dart'
+    if (dart.library.io) 'menu_item_image_io.dart'
+    if (dart.library.html) 'menu_item_image_web.dart';
+
+class MenuItemImage extends StatelessWidget {
+  final String imageUrl;
+  final double height;
+  final double width;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const MenuItemImage({
+    super.key,
+    required this.imageUrl,
+    required this.height,
+    required this.width,
+    this.fit = BoxFit.cover,
+    this.borderRadius,
+    this.placeholder,
+    this.errorWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuItemImageImpl(
+      imageUrl: imageUrl,
+      height: height,
+      width: width,
+      fit: fit,
+      borderRadius: borderRadius,
+      placeholder: placeholder,
+      errorWidget: errorWidget,
+    );
+  }
+}

--- a/lib/widgets/menu_item_image_impl.dart
+++ b/lib/widgets/menu_item_image_impl.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+/// Default implementation: just uses Image.network.
+class MenuItemImageImpl extends StatelessWidget {
+  final String imageUrl;
+  final double height;
+  final double width;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const MenuItemImageImpl({
+    super.key,
+    required this.imageUrl,
+    required this.height,
+    required this.width,
+    required this.fit,
+    required this.borderRadius,
+    required this.placeholder,
+    required this.errorWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = Image.network(
+      imageUrl,
+      height: height,
+      width: width,
+      fit: fit,
+      errorBuilder: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+    );
+
+    if (borderRadius != null) {
+      child = ClipRRect(borderRadius: borderRadius!, child: child);
+    }
+
+    return child;
+  }
+}

--- a/lib/widgets/menu_item_image_io.dart
+++ b/lib/widgets/menu_item_image_io.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+
+class MenuItemImageImpl extends StatelessWidget {
+  final String imageUrl;
+  final double height;
+  final double width;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const MenuItemImageImpl({
+    super.key,
+    required this.imageUrl,
+    required this.height,
+    required this.width,
+    required this.fit,
+    required this.borderRadius,
+    required this.placeholder,
+    required this.errorWidget,
+  });
+
+  bool get _isNetwork =>
+      imageUrl.startsWith('http://') || imageUrl.startsWith('https://');
+
+  bool get _isDataImage => imageUrl.startsWith('data:image/');
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child;
+
+    if (_isNetwork) {
+      child = CachedNetworkImage(
+        imageUrl: imageUrl,
+        height: height,
+        width: width,
+        fit: fit,
+        placeholder: (_, __) => placeholder ?? const SizedBox.shrink(),
+        errorWidget: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+      );
+    } else if (_isDataImage) {
+      final commaIndex = imageUrl.indexOf(',');
+      final dataPart = commaIndex >= 0
+          ? imageUrl.substring(commaIndex + 1)
+          : '';
+      final bytes = base64Decode(dataPart);
+      child = Image.memory(
+        bytes,
+        height: height,
+        width: width,
+        fit: fit,
+        errorBuilder: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+      );
+    } else {
+      child = Image.file(
+        File(imageUrl),
+        height: height,
+        width: width,
+        fit: fit,
+        errorBuilder: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+      );
+    }
+
+    if (borderRadius != null) {
+      child = ClipRRect(borderRadius: borderRadius!, child: child);
+    }
+
+    return child;
+  }
+}

--- a/lib/widgets/menu_item_image_web.dart
+++ b/lib/widgets/menu_item_image_web.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+
+class MenuItemImageImpl extends StatelessWidget {
+  final String imageUrl;
+  final double height;
+  final double width;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const MenuItemImageImpl({
+    super.key,
+    required this.imageUrl,
+    required this.height,
+    required this.width,
+    required this.fit,
+    required this.borderRadius,
+    required this.placeholder,
+    required this.errorWidget,
+  });
+
+  bool get _isNetwork =>
+      imageUrl.startsWith('http://') || imageUrl.startsWith('https://');
+
+  bool get _isDataImage => imageUrl.startsWith('data:image/');
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child;
+
+    if (_isNetwork) {
+      child = CachedNetworkImage(
+        imageUrl: imageUrl,
+        height: height,
+        width: width,
+        fit: fit,
+        placeholder: (_, __) => placeholder ?? const SizedBox.shrink(),
+        errorWidget: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+      );
+    } else if (_isDataImage) {
+      final commaIndex = imageUrl.indexOf(',');
+      final dataPart = commaIndex >= 0
+          ? imageUrl.substring(commaIndex + 1)
+          : '';
+      final bytes = base64Decode(dataPart);
+      child = Image.memory(
+        bytes,
+        height: height,
+        width: width,
+        fit: fit,
+        errorBuilder: (_, __, ___) => errorWidget ?? const SizedBox.shrink(),
+      );
+    } else {
+      // Unknown format on web.
+      child = errorWidget ?? const SizedBox.shrink();
+    }
+
+    if (borderRadius != null) {
+      child = ClipRRect(borderRadius: borderRadius!, child: child);
+    }
+
+    return child;
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import path_provider_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -145,6 +153,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -198,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_shaders:
     dependency: transitive
     description:
@@ -208,6 +256,11 @@ packages:
     version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -259,6 +312,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "518a16108529fc18657a3e6dde4a043dc465d16596d20ab2abd49a4cac2e703d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+13"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "956c16a42c0c708f914021666ffcd8265dde36e673c9fa68c81f7d085d9774ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+3"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -331,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -356,7 +481,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -626,4 +751,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
   cached_network_image: ^3.3.1
   hive_flutter: ^1.1.0
   google_fonts: ^6.2.1
+  image_picker: ^1.1.2
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Allow admin to add products to the menu with name/description/price/category and select an image from the device gallery. Persist selected images and render local/data/network image sources in the UI.